### PR TITLE
Use typos-mirror for pre-commit compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,9 @@ repos:
       - id: editorconfig-checker
 
   # Spelling
-  - repo: https://github.com/crate-ci/typos
+  # Use typos-mirror as typos uses a mutable tag:
+  # https://github.com/crate-ci/typos/issues/390
+  - repo: https://github.com/adhtruong/mirrors-typos
     rev: v1.36.2
     hooks:
       - id: typos


### PR DESCRIPTION
The original repository for typos provides a mutable tag.
pre-commit/prek auto updates always refer to that tag as 'latest'
version, but the version should be fixed. The typos-mirror repository
solves that.
